### PR TITLE
adds missing semicolons

### DIFF
--- a/conf/config.inc.php.example
+++ b/conf/config.inc.php.example
@@ -131,9 +131,9 @@ $mail_from = "admin@example.com";
 $notify_on_change = true;
 
 # default email domain
-$maildomain = "example.com"
+$maildomain = "example.com";
 # admin user email  ("@".$defaultdomain appended in code)
-$mailadminuser = "admin"
+$mailadminuser = "admin";
 
 ## SMS
 # Use sms


### PR DESCRIPTION
These missing semicolons cause the following error:

[error] 8379#0: _4 FastCGI sent in stderr: "PHP message: PHP Parse error:  syntax error, unexpected '$mailadminuser' (T_VARIABLE) in (DIRECOTRY)ldap-selfservice/conf/config.inc.php on line 136" while reading response header from upstream, client: 10.2.0.3, server: localhost, request: "GET /ldap/ HTTP/1.1", upstream: "fastcgi://unix:/var/run/php5-fpm.sock:", host: "_**"
